### PR TITLE
分かりやすさ重視でメニュー省略表記を変更

### DIFF
--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -13,17 +13,17 @@
                     <ul class="navbar-nav nav-underline">
                         <li class="nav-item">
                             <a th:href="@{/yearly}" class="nav-link" style="color:white;">
-                                年別
+                                年別資産グラフ
                             </a>
                         </li>
                         <li class="nav-item">
                             <a th:href="@{/monthly}" class="nav-link" style="color:white;">
-                                月別
+                                月別資産グラフ
                             </a>
                         </li>
                         <li class="nav-item">
                             <a th:href="@{/}" class="nav-link" style="color:white;">
-                                管理
+                                資産管理
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
<!--
日本語でのレビューをお願いします。
-->
# 概要
「月別」などの表記だけでは何なのか初見で分かりづらいため改善する
