### PR TITLE
月別資産グラフのlabelsをサーバで生成するよう変更

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,20 @@
             <version>2.3.230</version>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <version>2.4-M6-groovy-4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>4.0.27</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -52,6 +66,11 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.1.1</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,13 @@
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
                 <version>4.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compileTests</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <sources>
                         <source>src/test/groovy</source>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.example</groupId>
     <artifactId>visuasset</artifactId>
-    <version>0.10.0</version>
+    <version>0.11.0</version>
 
     <properties>
         <java.version>17</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,14 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
-                <version>2.1.1</version>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>4.2.0</version>
+                <configuration>
+                    <sources>
+                        <source>src/test/groovy</source>
+                    </sources>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/example/visuasset/controller/VisuassetController.java
+++ b/src/main/java/com/example/visuasset/controller/VisuassetController.java
@@ -82,9 +82,11 @@ public class VisuassetController {
         model.addAttribute("targetYear", targetYear);
         // 月別資産データ取得
         var monthlyAssetsList = monthlyAssetsService.getAssetsByYear(targetYear);
-        model.addAttribute("cashList", monthlyAssetsService.getCashListAsString(monthlyAssetsList));
-        model.addAttribute("securitiesList", monthlyAssetsService.getSecuritiesListAsString(monthlyAssetsList));
-        model.addAttribute("cryptoList", monthlyAssetsService.getCryptoListAsString(monthlyAssetsList));
+        model.addAttribute("cashList", monthlyAssetsService.getCashList(monthlyAssetsList));
+        model.addAttribute("securitiesList", monthlyAssetsService.getSecuritiesList(monthlyAssetsList));
+        model.addAttribute("cryptoList", monthlyAssetsService.getCryptoList(monthlyAssetsList));
+        // ラベル（データがある月のみ）をサーバー側で生成
+        model.addAttribute("labels", monthlyAssetsService.getMonthLabels(monthlyAssetsList));
         return "monthly";
     }
 }

--- a/src/main/java/com/example/visuasset/service/MonthlyAssetsService.java
+++ b/src/main/java/com/example/visuasset/service/MonthlyAssetsService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.function.Function;
 
 @Slf4j
 @Service
@@ -29,15 +30,27 @@ public class MonthlyAssetsService {
     }
 
     /**
+     * 共通の金額リスト取得ヘルパーメソッド
+     *
+     * @param monthlyAssetsList 月次資産エンティティのリスト
+     * @param mapper 金額を取得する関数
+     * @return 各月の金額一覧
+     */
+    private List<BigDecimal> getAmountList(List<MonthlyAssets> monthlyAssetsList,
+                                           Function<MonthlyAssets, BigDecimal> mapper) {
+        return monthlyAssetsList.stream()
+                .map(mapper)
+                .toList();
+    }
+
+    /**
      * 月次資産リストから現預金の金額一覧を取得します。
      *
      * @param monthlyAssetsList 月次資産エンティティのリスト
      * @return 各月の現預金金額一覧
      */
     public List<BigDecimal> getCashList(List<MonthlyAssets> monthlyAssetsList) {
-        return monthlyAssetsList.stream()
-                .map(MonthlyAssets::getCash)
-                .toList();
+        return getAmountList(monthlyAssetsList, MonthlyAssets::getCash);
     }
 
     /**
@@ -47,9 +60,7 @@ public class MonthlyAssetsService {
      * @return 各月の有価証券金額の一覧
      */
     public List<BigDecimal> getSecuritiesList(List<MonthlyAssets> monthlyAssetsList) {
-        return monthlyAssetsList.stream()
-                .map(MonthlyAssets::getSecurities)
-                .toList();
+        return getAmountList(monthlyAssetsList, MonthlyAssets::getSecurities);
     }
 
     /**
@@ -59,9 +70,7 @@ public class MonthlyAssetsService {
      * @return 各月の暗号資産金額の一覧
      */
     public List<BigDecimal> getCryptoList(List<MonthlyAssets> monthlyAssetsList) {
-        return monthlyAssetsList.stream()
-                .map(MonthlyAssets::getCrypto)
-                .toList();
+        return getAmountList(monthlyAssetsList, MonthlyAssets::getCrypto);
     }
 
     /**

--- a/src/main/java/com/example/visuasset/service/MonthlyAssetsService.java
+++ b/src/main/java/com/example/visuasset/service/MonthlyAssetsService.java
@@ -5,6 +5,7 @@ import com.example.visuasset.repository.MonthlyAssetsRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Slf4j
@@ -18,54 +19,63 @@ public class MonthlyAssetsService {
     }
 
     /**
-     * 指定した年の資産データ一覧を取得します。
+     * 指定した年の月次資産データ一覧を取得します。
      *
-     * @param year 年（例：2024）
-     * @return 指定年のMonthlyAssetsリスト
+     * @param year 取得対象の年（例：2024）
+     * @return 指定年のMonthlyAssetsエンティティのリスト
      */
     public List<MonthlyAssets> getAssetsByYear(int year) {
         return repository.findByTargetYear(year);
     }
 
     /**
-     * 現預金（cash）一覧をカンマ区切りの文字列に変換します。
+     * 月次資産リストから現預金の金額一覧を取得します。
      *
-     * @param monthlyAssetsList MonthlyAssetsのリスト
-     * @return 現預金の値をカンマ区切りで連結した文字列
+     * @param monthlyAssetsList 月次資産エンティティのリスト
+     * @return 各月の現預金金額一覧
      */
-    public String getCashListAsString(List<MonthlyAssets> monthlyAssetsList) {
+    public List<BigDecimal> getCashList(List<MonthlyAssets> monthlyAssetsList) {
         return monthlyAssetsList.stream()
                 .map(MonthlyAssets::getCash)
-                .map(Object::toString)
-                .reduce((s1, s2) -> s1 + ", " + s2)
-                .orElse("");
+                .toList();
     }
 
     /**
-     * 有価証券（securities）一覧をカンマ区切りの文字列に変換します。
+     * 月次資産リストから有価証券の金額一覧を取得します。
      *
-     * @param monthlyAssetsList MonthlyAssetsのリスト
-     * @return 有価証券の値をカンマ区切りで連結した文字列
+     * @param monthlyAssetsList 月次資産エンティティのリスト
+     * @return 各月の有価証券金額の一覧
      */
-    public String getSecuritiesListAsString(List<MonthlyAssets> monthlyAssetsList) {
+    public List<BigDecimal> getSecuritiesList(List<MonthlyAssets> monthlyAssetsList) {
         return monthlyAssetsList.stream()
                 .map(MonthlyAssets::getSecurities)
-                .map(Object::toString)
-                .reduce((s1, s2) -> s1 + ", " + s2)
-                .orElse("");
+                .toList();
     }
 
     /**
-     * 暗号資産（crypto）一覧をカンマ区切りの文字列に変換します。
+     * 月次資産リストから暗号資産の金額一覧を取得します。
      *
-     * @param monthlyAssetsList MonthlyAssetsのリスト
-     * @return 暗号資産の値をカンマ区切りで連結した文字列
+     * @param monthlyAssetsList 月次資産エンティティのリスト
+     * @return 各月の暗号資産金額の一覧
      */
-    public String getCryptoListAsString(List<MonthlyAssets> monthlyAssetsList) {
+    public List<BigDecimal> getCryptoList(List<MonthlyAssets> monthlyAssetsList) {
         return monthlyAssetsList.stream()
                 .map(MonthlyAssets::getCrypto)
-                .map(Object::toString)
-                .reduce((s1, s2) -> s1 + ", " + s2)
-                .orElse("");
+                .toList();
+    }
+
+    /**
+     * 月次資産リストからデータが存在する月のみのラベルリストを返す
+     *
+     * @param monthlyAssetsList 月次資産エンティティのリスト
+     * @return データが存在する月のラベルリスト（例: ["1月", "3月", ...]）
+     */
+    public List<String> getMonthLabels(List<MonthlyAssets> monthlyAssetsList) {
+        return monthlyAssetsList.stream()
+                .map(MonthlyAssets::getTargetMonth)
+                .distinct()
+                .sorted()
+                .map(i -> i + "月")
+                .toList();
     }
 }

--- a/src/main/resources/templates/monthly.html
+++ b/src/main/resources/templates/monthly.html
@@ -29,15 +29,16 @@
     </form>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
-    <script>
-        const cashList = [ [[${cashList}]] ];
-        const securitiesList = [ [[${securitiesList}]] ];
-        const cryptoList = [ [[${cryptoList}]] ];
+    <script th:inline="javascript">
+        const cashList = /*[[${cashList}]]*/ [];
+        const securitiesList = /*[[${securitiesList}]]*/ [];
+        const cryptoList = /*[[${cryptoList}]]*/ [];
+        const labels = /*[[${labels}]]*/ [];
         const ctx = document.getElementById("monthly");
         const chart = new Chart(ctx, {
             type: 'bar',
             data: {
-                labels: ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"],
+                labels: labels,
                 datasets: [
                     {
                         label: '現預金',

--- a/src/test/groovy/com/example/visuasset/service/MonthlyAssetsServiceSpec.groovy
+++ b/src/test/groovy/com/example/visuasset/service/MonthlyAssetsServiceSpec.groovy
@@ -4,6 +4,55 @@ import com.example.visuasset.entity.MonthlyAssets
 import spock.lang.Specification
 
 class MonthlyAssetsServiceSpec extends Specification {
+
+    def "getCashList 現預金金額リストを返す"() {
+        given:
+        def service = new MonthlyAssetsService(null)
+        def monthlyAssetsList = [
+                Stub(MonthlyAssets) { getCash() >> 100.0 },
+                Stub(MonthlyAssets) { getCash() >> 200.0 },
+                Stub(MonthlyAssets) { getCash() >> 300.0 }
+        ]
+
+        when:
+        def result = service.getCashList(monthlyAssetsList)
+
+        then:
+        result == [100.0, 200.0, 300.0]
+    }
+
+    def "getSecuritiesList 有価証券金額リストを返す"() {
+        given:
+        def service = new MonthlyAssetsService(null)
+        def monthlyAssetsList = [
+                Stub(MonthlyAssets) { getSecurities() >> 10.5 },
+                Stub(MonthlyAssets) { getSecurities() >> 20.5 },
+                Stub(MonthlyAssets) { getSecurities() >> 30.5 }
+        ]
+
+        when:
+        def result = service.getSecuritiesList(monthlyAssetsList)
+
+        then:
+        result == [10.5, 20.5, 30.5]
+    }
+
+    def "getCryptoList 暗号資産金額リストを返す"() {
+        given:
+        def service = new MonthlyAssetsService(null)
+        def monthlyAssetsList = [
+                Stub(MonthlyAssets) { getCrypto() >> 1.1 },
+                Stub(MonthlyAssets) { getCrypto() >> 2.2 },
+                Stub(MonthlyAssets) { getCrypto() >> 3.3 }
+        ]
+
+        when:
+        def result = service.getCryptoList(monthlyAssetsList)
+
+        then:
+        result == [1.1, 2.2, 3.3]
+    }
+
     def "getMonthLabels 月のラベルリストを返す"() {
         given:
         def service = new MonthlyAssetsService(null)

--- a/src/test/groovy/com/example/visuasset/service/MonthlyAssetsServiceSpec.groovy
+++ b/src/test/groovy/com/example/visuasset/service/MonthlyAssetsServiceSpec.groovy
@@ -1,0 +1,23 @@
+package com.example.visuasset.service
+
+import com.example.visuasset.entity.MonthlyAssets
+import spock.lang.Specification
+
+class MonthlyAssetsServiceSpec extends Specification {
+    def "getMonthLabels 月のラベルリストを返す"() {
+        given:
+        def service = new MonthlyAssetsService(null)
+        def monthlyAssetsList = [
+                Stub(MonthlyAssets) { getTargetMonth() >> 1 },
+                Stub(MonthlyAssets) { getTargetMonth() >> 3 },
+                Stub(MonthlyAssets) { getTargetMonth() >> 2 },
+                Stub(MonthlyAssets) { getTargetMonth() >> 1 }
+        ]
+
+        when:
+        def result = service.getMonthLabels(monthlyAssetsList)
+
+        then:
+        result == ["1月", "2月", "3月"]
+    }
+}


### PR DESCRIPTION
<!--
日本語でのレビューをお願いします。
-->
# 内容
- 月別資産グラフのlabelsをサーバで生成するよう変更
  - テストコードも追加
- 上記に合わせて周辺処理も見直し

# 動作確認

- [x] 月別資産グラフの表示ができること
- [x] 月別資産グラフでデータがある月だけが表示されること

